### PR TITLE
⚡ Bolt: Optimize selected symptoms lookup and fix type error

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -3,3 +3,7 @@
 ## 2025-05-24 - [Recreating Objects in Render Loop]
 **Learning:** Defining constant maps or objects inside helper functions that are called frequently (like inside `map` or render loops) causes unnecessary garbage collection and object allocation.
 **Action:** Move static configuration objects, lookup maps, and icon dictionaries outside of the component or function scope to module scope.
+
+## 2025-05-24 - [Selected Items Lookup in Filtered Lists]
+**Learning:** When rendering a list of "selected" items that are a subset of a large dataset, avoid searching for them in the *filtered* view data (O(N) search). This causes performance issues when filters change (typing search terms) and can cause selected items to disappear if they don't match the current filter.
+**Action:** Create a memoized `Map` keyed by ID from the *full* dataset (not filtered) to allow O(1) lookup of selected item details. This improves rendering performance and ensures consistent UI state.

--- a/src/components/repertory/ProfessionalRepertoryBrowser.tsx
+++ b/src/components/repertory/ProfessionalRepertoryBrowser.tsx
@@ -43,6 +43,13 @@ interface Symptom {
   prevalence?: number;
 }
 
+const REMEDY_COLORS = {
+  1: "bg-slate-100 text-slate-800 border-slate-200",
+  2: "bg-blue-100 text-blue-800 border-blue-200 italic",
+  3: "bg-red-100 text-red-800 border-red-200 font-bold",
+  4: "bg-red-100 text-red-800 border-red-200 font-bold uppercase"
+};
+
 const CATEGORY_ICONS: { [key: string]: React.ElementType } = {
   'Mind': Brain,
   'Head': User,
@@ -328,6 +335,19 @@ export const ProfessionalRepertoryBrowser: React.FC<ProfessionalRepertoryBrowser
     return filtered;
   }, [categories, selectedCategory, debouncedSearchTerm, filterGrade, sortBy]);
 
+  // Optimization: specific symptom lookup map to avoid O(N) searches in render loop
+  const symptomLookup = useMemo(() => {
+    const lookup = new Map<string, Symptom>();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    categories.forEach((cat: any) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      cat.symptoms.forEach((symptom: any) => {
+        lookup.set(symptom.id, symptom);
+      });
+    });
+    return lookup;
+  }, [categories]);
+
   const toggleSymptomSelection = useCallback((symptomId: string) => {
     setSelectedSymptoms(prev => 
       prev.includes(symptomId) 
@@ -585,11 +605,7 @@ export const ProfessionalRepertoryBrowser: React.FC<ProfessionalRepertoryBrowser
           <CardContent>
             <div className="flex flex-wrap gap-2">
               {selectedSymptoms.map(symptomId => {
-                const symptom = filteredData
-                  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                  .flatMap((cat: any) => cat.symptoms)
-                  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                  .find((s: any) => s.id === symptomId);
+                const symptom = symptomLookup.get(symptomId);
                 return symptom ? (
                   <Badge key={symptomId} variant="secondary" className="text-sm">
                     {symptom.description}


### PR DESCRIPTION
⚡ Bolt: Optimize selected symptoms lookup and fix type error

This PR addresses a performance bottleneck in the `ProfessionalRepertoryBrowser` component.

1.  **Optimization:**
    -   Previously, rendering the "Selected Symptoms Analysis" section involved iterating through `selectedSymptoms` and for each one, performing a `flatMap` and `find` operation on the `filteredData`. This resulted in O(M * N) complexity on every render.
    -   I introduced a `symptomLookup` Map, memoized based on the full `categories` data. This allows for O(1) retrieval of symptom details.
    -   This change improves responsiveness, especially when the dataset is large or when filters (like search terms) are applied frequently.

2.  **Bug Fix:**
    -   The `REMEDY_COLORS` constant was missing from the file, causing TypeScript errors. I restored it to ensure the code compiles and renders remedy badges correctly.

3.  **UX Improvement:**
    -   By using the full `categories` data for the lookup instead of `filteredData`, selected symptoms now persist in the "Selected Analysis" bar even if the user filters them out of the main list (e.g., by searching for a different symptom).

**Verification:**
-   Verified via manual review and Playwright script (temporary) that the component renders correctly and selected symptoms are displayed.
-   Passed `pnpm type-check` and `pnpm lint`.

---
*PR created automatically by Jules for task [4825446029987213711](https://jules.google.com/task/4825446029987213711) started by @tanhomoeo*